### PR TITLE
Add article about i18n gotcha encountered in release last week

### DIFF
--- a/_posts/2016-08-08-how-missing-translations-in-rails-can-mess-with-your-markup.markdown
+++ b/_posts/2016-08-08-how-missing-translations-in-rails-can-mess-with-your-markup.markdown
@@ -1,0 +1,53 @@
+---
+layout: post
+title:  "How missing translations in Rails can mess with your markup"
+date:   2016-08-08 10:00:00
+author: kjcpaas
+comments: true
+---
+
+Last week, we experienced something that we never thought will happen. Some missing translations messed up the content and layout of one of our landing pages.
+
+This is how we expected it to look like:
+
+![](https://cloud.githubusercontent.com/assets/3772828/17467365/191cc510-5d50-11e6-9a3e-5136f6c3a2c7.png)
+
+However, it looked like this:
+
+![](https://cloud.githubusercontent.com/assets/3772828/17333416/e54cff24-5904-11e6-8a68-dd0e19a9b9b0.png)
+
+Furthermore, in mobile, it messed the page layout by content div being pushed inwards due to the long string.
+
+![](https://cloud.githubusercontent.com/assets/1891005/17333948/5ac59c36-58cc-11e6-9f7f-a2b5179bde08.png)
+
+## Investigation
+
+We found out that it's due to I18n's missing translation message.
+
+![This image show missing translation error for `es-MX` but this also happens to other locales like `th`](https://cloud.githubusercontent.com/assets/1628558/17333775/941efe42-58cb-11e6-8f40-82413af4fb9d.png)
+
+Notice that the message is enclosed in a `<span></span>` element. However, since the translated segment was being used as the value for the images' alt, the span element messed with the alt's value. Unfortunately, the segments being used as image alt were not yet available for certain locales.
+
+This code was tracked to [this line](https://github.com/rails/rails/blob/c1dbb13eacf0e579f351a46c9ee2ec845ae0cc2d/actionview/lib/action_view/helpers/translation_helper.rb#L108) in `ActionView#TranslationHelpers`.
+
+## Solution
+
+After reading the method in `ActionView#TranslationHelpers`, we found a way on how to workaround this problem. By passing a `:default` paramater in or `t` method call in the view, we were able to override the default `span` return element on missing translation.
+
+__Before fix__
+
+```ruby
+= image_tag 'my_image.gif', alt: t('my.missing.segment')
+```
+
+We set `:default` to a blank string.
+
+__The fix__
+
+```ruby
+= image_tag 'my_image.gif', alt: t('my.missing.segment', default: '')
+```
+
+After applying the simple fix, the images showed as expected!
+
+![](https://cloud.githubusercontent.com/assets/3772828/17467365/191cc510-5d50-11e6-9a3e-5136f6c3a2c7.png)

--- a/_posts/2016-08-08-how-missing-translations-in-rails-can-mess-with-your-markup.markdown
+++ b/_posts/2016-08-08-how-missing-translations-in-rails-can-mess-with-your-markup.markdown
@@ -51,3 +51,11 @@ __The fix__
 After applying the simple fix, the images showed as expected!
 
 ![](https://cloud.githubusercontent.com/assets/3772828/17467365/191cc510-5d50-11e6-9a3e-5136f6c3a2c7.png)
+
+### Rails 5 Alternative
+
+If you are using Rails 5, you can also set this config in your `application.rb`.
+
+```ruby
+config.action_view.debug_missing_translation = false
+```


### PR DESCRIPTION
This documents the release blocker we encountered last week around I18n.

You may look at this [issue](https://github.com/quipper/quipper/issues/6194) and [PR](https://github.com/quipper/video-payment-qs/issues/1394) for reference.

Enjoy!

<img width="372" alt="screen shot 2016-08-08 at 10 46 24 am" src="https://cloud.githubusercontent.com/assets/3772828/17467935/8944db48-5d55-11e6-9cbe-9136892d0fef.png">

@quipper/devs 